### PR TITLE
updated deprecated redirect to :back methods

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -34,7 +34,7 @@ class Admin::AdminController < ApplicationController
   def build_report
     if params[:selected_reports].blank?
       flash_message :warning, "You must select at least one report item"
-      redirect_to :back
+      redirect_back(fallback_location: root_path)
       return
     end
 
@@ -73,7 +73,7 @@ class Admin::AdminController < ApplicationController
     end
 
     flash_message :info, "You should receive an email shortly"
-    redirect_to :back
+    redirect_back(fallback_location: root_path)
   end
 
   def update_stats
@@ -87,7 +87,7 @@ class Admin::AdminController < ApplicationController
       end
       flash_message :warning, "#{ActionController::Base.helpers.sanitize sessionless_course_warning}"
     end
-    redirect_to :back
+    redirect_back(fallback_location: root_path)
   end
 
   def clear_mail_queue

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -33,7 +33,7 @@ class CoursesController < ApplicationController
     end
 
     respond_to do |format|
-      format.html { redirect_to :back }
+      format.html { redirect_back(fallback_location: root_path) }
     end
   end
 
@@ -403,7 +403,7 @@ class CoursesController < ApplicationController
     end
 
     respond_to do |format|
-      format.html { redirect_to :back }
+      format.html { redirect_back(fallback_location: root_path) }
     end
   end
 


### PR DESCRIPTION
`redirect_to :back` has been deprecated as of Rails 5 (https://blog.bigbinary.com/2016/02/29/rails-5-improves-redirect_to_back-with-redirect-back.html). It's been replaced with the new patterning. Easiest way to test out the new functionality is to cancel and uncancel a class.